### PR TITLE
Index hashtags, and ... mentions.  Also allow the user to specify that the tweet text to be markedup.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'rmagick4j'
 gem 'exifr'
 gem 'puma'
 
+gem 'twitter-text', '~> 1.10.0'
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
       polyglot (>= 0.3.1)
     turn (0.8.2)
       ansi (>= 1.2.2)
+    twitter-text (1.10.0)
+      unf (~> 0.1.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     tzinfo-data (1.2014.5)
@@ -165,6 +167,7 @@ GEM
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     underscore-rails (1.6.0)
+    unf (0.1.4-java)
 
 PLATFORMS
   java
@@ -191,6 +194,7 @@ DEPENDENCIES
   sdoc
   therubyrhino
   turn (< 0.8.3)
+  twitter-text (~> 1.10.0)
   tzinfo-data
   uglifier (>= 1.3.0)
   underscore-rails

--- a/app/controllers/api/v2/module.rb
+++ b/app/controllers/api/v2/module.rb
@@ -1,0 +1,6 @@
+module API
+  # noinspection ALL
+  module V2
+
+  end
+end

--- a/app/controllers/api/v2/stream_controller.rb
+++ b/app/controllers/api/v2/stream_controller.rb
@@ -1,9 +1,11 @@
 class API::V2::StreamController < ApplicationController
+  include Twitter::Autolink
+  # noinspection RailsParamDefResolve
   skip_before_action :verify_authenticity_token
 
   PAGE_LENGTH = 20
   before_filter :login_required
-  before_filter :fetch_post, :except => [:index, :create]
+  before_filter :fetch_post, :except => [:index, :create, :view_mention, :view_hash_tag]
 
   def login_required
     head :unauthorized unless logged_in?
@@ -31,6 +33,23 @@ class API::V2::StreamController < ApplicationController
 
   def show
     render_json @post.decorate.to_hash
+  end
+
+  def view_mention
+    query_string = params[:query]
+    start_loc = params[:page] || 0
+    limit = params[:limit] || PAGE_LENGTH
+    query = StreamPost.where(mentions: query_string).order_by(timestamp: :desc).skip(start_loc*limit).limit(limit)
+    render status: :ok, json: {status: 'ok', posts: query.map { |x| x.decorate.to_list_hash }, next:(start_loc+limit)}
+  end
+
+  def view_hash_tag
+    query_string = params[:query]
+    start_loc = params[:page] || 0
+    limit = params[:limit] || PAGE_LENGTH
+    query = StreamPost.where(hash_tags: query_string).order_by(timestamp: :desc).skip(start_loc*limit).limit(limit)
+    render status: :ok, json: {status: 'ok', posts: query.map { |x| x.decorate.to_list_hash }, next:(start_loc+limit)}
+
   end
 
   def destroy
@@ -97,11 +116,29 @@ class API::V2::StreamController < ApplicationController
     limit = params[:limit] || PAGE_LENGTH
     posts = StreamPost.at_or_before(start_loc, author).limit(limit).order_by(timestamp: :desc).map { |x| x }
     next_page = posts.last.nil? ? 0 : (posts.last.timestamp.to_f * 1000).to_i - 1
-    {stream_posts: posts.map { |x| x.decorate.to_list_hash }, next_page: next_page}
+    {stream_posts: generate_return_map(posts, params.has_key?(:auto_link)), next_page: next_page}
   end
 
   def want_newer_posts?
     params.has_key?(:start) and not params.has_key?(:older_posts)
+  end
+
+  def generate_return_map(posts, desire_auto_link)
+    posts = posts.map { |x| x.decorate.to_list_hash }
+    posts = posts.map { |x| do_auto_link(x) } if desire_auto_link
+    posts
+  end
+
+
+  # TODO: get Nate to fill in these with real good default values
+  DEFAULT_LINK_OPTIONS = { :username_url_base => '/users/',  :list_url_base => '/lists/', :hashtag_url_base => '/stream/h/', :cashtag_url_base => '/stream/c/' }.freeze
+  def do_auto_link(post)
+    link_options = DEFAULT_LINK_OPTIONS.merge params.slice [ :list_class, :username_class, :hashtag_class, :cashtag_class, :username_url_base,
+                   :list_url_base, :hashtag_url_base, :cashtag_url_base, :invisible_tag_attrs ]
+
+    post[:text] = auto_link(post[:text], link_options)
+    post.delete :entities
+    post
   end
 
   def newer_posts
@@ -110,6 +147,6 @@ class API::V2::StreamController < ApplicationController
     limit = params[:limit] || PAGE_LENGTH
     posts = StreamPost.at_or_after(start_loc, author).limit(limit).order_by(timestamp: :asc).map { |x| x }
     next_page = posts.last.nil? ? 0 : (posts.first.timestamp.to_f * 1000).to_i + 1
-    {stream_posts: posts.map { |x| x.decorate.to_list_hash }, next_page: next_page}
+    {stream_posts: generate_return_map(posts, params.has_key?(:auto_link)), next_page: next_page}
   end
 end

--- a/app/decorators/stream_post_decorator.rb
+++ b/app/decorators/stream_post_decorator.rb
@@ -1,3 +1,4 @@
+# noinspection RubyResolve
 class StreamPostDecorator < Draper::Decorator
   delegate_all
 
@@ -12,6 +13,9 @@ class StreamPostDecorator < Draper::Decorator
         likes: likes,
         likes_counts: likes.length,
         epoch: (timestamp.to_f * 1000).to_i,
+        mentions: mentions,
+        entities: entities,
+        hash_tags: hash_tags,
         photo: photo
     }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Twitarr::Application.routes.draw do
       resources :stream, only: [:index, :new, :create, :show, :destroy]
       post 'stream/:id/like', to: 'stream#like'
       delete 'stream/:id/like', to: 'stream#unlike'
+      get 'stream/m/:query', to: 'stream#view_mention'
+      get 'stream/h/:query', to: 'stream#view_hash_tag'
       get 'stream/:id/like', to: 'stream#show_likes'
       get 'user/new_seamail', to: 'user#new_seamail'
       get 'user/auth', to: 'user#auth'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,6 +32,7 @@ unless User.exist? 'admin'
   user.save
 end
 
+# noinspection RubyResolve
 def add_photo(url, localfilename, uploader, upload_date)
 
   photo_basename = File.basename localfilename
@@ -51,6 +52,8 @@ def add_photo(url, localfilename, uploader, upload_date)
   photo_md.save!
   photo_md
 end
+
+# noinspection RubyResolve
 Mongoid.raise_not_found_error = false
 photos = []
 Dir.mktmpdir do |dir|
@@ -111,9 +114,9 @@ if StreamPost.count == 0
   create_post 'Where the dead man called out for his love to flee #mockingjay', 'steve', DateTime.civil(2014, 10, 14, 11, 26), nil
 
   create_post 'Nike+ bracelet thingie verdict: it successfully guilted me into learning guitar by fighting zombies.', 'steve', DateTime.civil(2014, 10, 14, 11, 27), nil
-  create_post 'I may have eaten too much cake.', 'kvort', DateTime.civil(2014, 10, 14, 11, 28), nil, %w(james)
-  create_post '@kvort you can never have too much cake.', 'steve', DateTime.civil(2014, 10, 14, 11, 29), nil, %w(kvort)
-  create_post '@kvort though you can never eat to much cookies', 'james', DateTime.civil(2014, 10, 14, 11, 30), nil, %w(steven)
+  create_post 'I may have eaten too much #cake.', 'kvort', DateTime.civil(2014, 10, 14, 11, 28), nil, %w(james)
+  create_post '@kvort you can never have too much #cake.', 'steve', DateTime.civil(2014, 10, 14, 11, 29), nil, %w(kvort)
+  create_post '@kvort though you can never eat to much #cookies', 'james', DateTime.civil(2014, 10, 14, 11, 30), nil, %w(steven)
   create_post '@james challenge accepted.', 'kvort', DateTime.civil(2014, 10, 14, 11, 31), nil, %w(james steven)
   create_post 'Whats the over/under?', 'steve', DateTime.civil(2014, 10, 14, 11, 32), nil, %w(kvort james steven)
 end


### PR DESCRIPTION
The backend code for https://github.com/walkeriniraq/twitarr/issues/125

This adds:
GET http://localhost:3000/api/v2/stream/m/:username
and
GET http://localhost:3000/api/v2/stream/h/:hash_tag

Also allows the URL param for the stream: &auto_link=true
Which will markup the text of the post.

When enabled, you can also specify these options to customize the linking:
:list_class, :username_class, :hashtag_class, :cashtag_class, :username_url_base, :list_url_base, :hashtag_url_base, :cashtag_url_base, :invisible_tag_attrs

See https://github.com/twitter/twitter-text-rb/blob/master/lib/twitter-text/autolink.rb#L11 for a description of what each one does.
