### PR TITLE
Having :location in the forum decorator breaks the forum

### DIFF
--- a/app/decorators/forum_post_decorator.rb
+++ b/app/decorators/forum_post_decorator.rb
@@ -12,7 +12,7 @@ class ForumPostDecorator < BaseDecorator
         likes_counts: likes.length,
         photos: decorate_photos,
         hash_tags: hash_tags,
-        location: location,
+#        location: location,
         mentions: mentions
     }
     ret[:new] = (timestamp > last_view) unless last_view.nil?


### PR DESCRIPTION

Location isn't fully implemented.  In the forum it yields a 500 error.  Disable for now, then re-enable once location is implemented in the forum decorator and visual interface.