### PR TITLE
fix event controller/event editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,15 @@
 !/log/.keep
 /tmp
 
+# vi editor droppings
+.*.swp
+
 /config/application.yml
 /config/mongoid.yml
 /config/secrets.yml
 
 /public/img/photos/*
+/public/cm/*
 
 *.gem
 *.rbc

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,6 +32,7 @@ class Event
     event.description = options[:description] unless options[:description].nil?
     event.location = options[:location] unless options[:location].nil?
     event.visibility = options[:visibility] unless options[:visibility].nil?
+    event.official = options[:official] unless options[:official].nil?
     event.end_time = options[:end_time] unless options[:end_time].nil?
     event.max_signups = options[:max_signups] unless options[:max_signups].nil?
     event.save if event.valid?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,6 +31,7 @@ class Event
     event = Event.new(author: author, title: title, start_time: start_time)
     event.description = options[:description] unless options[:description].nil?
     event.location = options[:location] unless options[:location].nil?
+    event.visibility = options[:visibility] unless options[:visibility].nil?
     event.end_time = options[:end_time] unless options[:end_time].nil?
     event.max_signups = options[:max_signups] unless options[:max_signups].nil?
     event.save if event.valid?


### PR DESCRIPTION
This PR fixes a number of bugs in the event rest API.  I can now create/edit/delete/favorite/unfavorite events properly from within CruiseMonkey with these changes.