### PR TITLE
Changes in build to support remote (offline) client sync

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'momentjs-rails'
 
 gem 'icalendar', '>= 2.3.0'
 
+# mongoid-paranoia for soft deletes, because we're still on mongoid 4
+gem 'mongoid-paranoia'
+
 group :development do
   gem 'better_errors'
 end

--- a/app/controllers/forums_controller.rb
+++ b/app/controllers/forums_controller.rb
@@ -69,8 +69,8 @@ class ForumsController < ApplicationController
     end
 
     if forum_post.valid?
-      forum_post.destroy!
-      forum.destroy! if forum.posts.count <= 1 # If the post is *only* the OP, delete the forum, else everything breaks
+      forum_post.destroy
+      forum.destroy if forum.posts.count <= 1 # If the post is *only* the OP, delete the forum, else everything breaks
       render_json status: 'OK'
     end
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event
   include Mongoid::Document
+  include Mongoid::Timestamps
   include Searchable
 
   FIRST_CRUISE_DATE = Date.new 2017, 3, 4

--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -1,5 +1,7 @@
 class Forum
   include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Paranoia
   include Searchable
 
   field :sj, as: :subject, type: String

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -1,5 +1,7 @@
 class ForumPost
   include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Paranoia
   include Searchable
   include Postable
 

--- a/app/models/seamail.rb
+++ b/app/models/seamail.rb
@@ -1,5 +1,7 @@
 class Seamail
   include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Paranoia
   include Searchable
 
   field :sj, as: :subject, type: String

--- a/app/models/seamail_message.rb
+++ b/app/models/seamail_message.rb
@@ -1,5 +1,7 @@
 class SeamailMessage
   include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Paranoia
 
   field :au, as: :author, type: String
   field :tx, as: :text, type: String

--- a/app/models/stream_post.rb
+++ b/app/models/stream_post.rb
@@ -1,6 +1,8 @@
 # noinspection RubyStringKeysInHashInspection
 class StreamPost
   include Mongoid::Document
+  include Mongoid::Timestamps
+  include Mongoid::Paranoia
   include Searchable
   include Postable
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ require 'bcrypt'
 
 class User
   include Mongoid::Document
+  include Mongoid::Timestamps
   include Searchable
 
   USERNAME_CACHE_TIME = 30.minutes


### PR DESCRIPTION
These should be the only changes needed that affect mongo itself – they only add automatically tracked fields, and Paranoia creates a new .deleted scope. Intention is that only new API and associated routes.rb changes will follow for 2018.

Oops, forgot one. app/controllers/forum_controller.rb uses destructive 'destroy!' which is incompatible with Paranoia tracking. I *think* this change to 'destroy' will still be fine as the count check doesn't change, but not entirely sure I understand the implication (or callbacks) on embedded documents.