### PR TITLE
MOAR sched.com failure to escape

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -84,7 +84,7 @@ class AdminController < ApplicationController
 
   def upload_schedule
     upload = params[:schedule].tempfile.read
-    temp = upload.gsub(/&amp;/, '&')
+    temp = upload.gsub(/&amp;/, '&').gsub(/;/, '\;')
     Icalendar.parse(temp).first.events.map { |x| Event.create_from_ics x }
     render_json status: 'ok'
   end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -84,7 +84,7 @@ class AdminController < ApplicationController
 
   def upload_schedule
     upload = params[:schedule].tempfile.read
-    temp = upload.gsub(/&amp;/, '&').gsub(/;/, '\;')
+    temp = upload.gsub(/&amp;/, '&').gsub(/(?<!\\);/, '\;')
     Icalendar.parse(temp).first.events.map { |x| Event.create_from_ics x }
     render_json status: 'ok'
   end


### PR DESCRIPTION
bozos!
fix ';' -> '\;'
er, improve to only match ';' but not '\;' in case they ever fix it